### PR TITLE
adding dropwizard-keycloak as a module

### DIFF
--- a/_data/modules/thirdparty.yaml
+++ b/_data/modules/thirdparty.yaml
@@ -16,6 +16,11 @@
     url: https://repo1.maven.org/maven2/be/fluid-it/tools/dropwizard/wizard-in-a-box
     groupId: be.fluid-it.tools.dropwizard
     artifactId: wizard-in-a-box
+- name: dropwizard-keycloak
+  url: https://github.com/ahus1/keycloak-dropwizard-integration/
+  description: Integration of OAuth2 by using JBoss Keycloak
+  dropwizard: 0.8
+  license: Apache 2.0
 - name: dropwizard-heroku
   url: https://github.com/login-box/dropwizard-heroku
   description: Configuration glue to run Dropwizard on Heroku

--- a/_layouts/thirdparty_modules.html
+++ b/_layouts/thirdparty_modules.html
@@ -24,7 +24,11 @@ layout: default
       <td><a href="{{ module.url }}">{{ module.name }}</a></td>
       <td>{{ module.description }}</td>
       <td>{{ module.license }}</td>
-      <td><a href="{{ module.maven.url }}">Details</a></td>
+      <td>
+      {% if module.maven != null %}
+        <a href="{{ module.maven.url }}">Details</a>
+      {% endif %}
+      </td>
       <td>{{ module.dropwizard }}</td>
     </tr>
 {% endfor %}


### PR DESCRIPTION
there is no publicly downloadable maven artefact yet, so I left the maven part empty. I will add it as soon as my module has been released.
