### PR TITLE
Updated Websocket Project Dropwizard version.

### DIFF
--- a/_data/modules/thirdparty.yaml
+++ b/_data/modules/thirdparty.yaml
@@ -142,6 +142,16 @@
     url: https://repo1.maven.org/maven2/de/ahus1/keycloak/dropwizard/keycloak-dropwizard/
     groupId: de.ahus1.keycloak.dropwizard
     artifactId: keycloak-dropwizard
+- name: dropwizard-websocket-jee7
+  url: https://github.com/TomCools/dropwizard-websocket-jee7-bundle
+  description: A bundle that adds support for the JSR 356 Websocket specification.
+  dropwizard: 0.9.1
+  license: Apache 2.0
+  maven:
+    url: https://oss.sonatype.org/content/repositories/releases/be/tomcools/dropwizard-websocket-jee7-bundle/
+    groupId: be.tomcools
+    artifactId: dropwizard-websocket-jee7-bundle
+## 0.8
 - name: encrypted-config-value-bundle
   url: https://github.com/palantir/encrypted-config-value
   description: support substituting encrypted values into configuration using standard `\${...}` syntax
@@ -208,15 +218,6 @@
   license: MIT
   maven:
       url: https://bintray.com/arteam/maven/jdit
-- name: dropwizard-websocket-jee7
-  url: https://github.com/TomCools/dropwizard-websocket-jee7-bundle
-  description: A bundle that adds support for the JSR 356 Websocket specification.
-  dropwizard: 0.8
-  license: Apache 2.0
-  maven:
-    url: https://oss.sonatype.org/content/repositories/releases/be/tomcools/dropwizard-websocket-jee7-bundle/
-    groupId: be.tomcools
-    artifactId: dropwizard-websocket-jee7-bundle
 ## 0.7
 - name: dropwizard-guice
   url: https://github.com/HubSpot/dropwizard-guice


### PR DESCRIPTION
I have released a new version of the Websocket Bundle. This new bundle now runs on 0.9.1.
I have changed the dropwizard number to 0.9.1 and put it a bit higher in the list, since it seems you rank the Bundles based on Dropwizard support.

Kind regards,
Tom
