### PR TITLE
Add dropwizard-pac4j

### DIFF
--- a/_data/modules/thirdparty.yaml
+++ b/_data/modules/thirdparty.yaml
@@ -10,6 +10,15 @@
 ## repository to update compatibility info.
 
 ## Bundles that have been tested on Dropwizard 1.0
+- name: dropwizard-pac4j
+  url: https://github.com/pac4j/dropwizard-pac4j
+  description: A Dropwizard bundle for securing REST endpoints using pac4j
+  dropwizard: 1.0.3
+  license: Apache 2.0
+  maven:
+    url: http://central.maven.org/maven2/org/pac4j/dropwizard-pac4j/
+    grouId: org.pac4j
+    artifactId: dropwizard-pac4j
 - name: encrypted-config-value-bundle
   url: https://github.com/palantir/encrypted-config-value
   description: support substituting encrypted values into configuration using standard `\${...}` syntax


### PR DESCRIPTION
This adds dropwizard-pac4j, which version 1.0.0 was just released.

I added it at the beginning to follow the alphabetical order, but I don't think it is really followed in practice in the file… ! :)