### PR TITLE
Addition of btm-DropwizardHealthChecks to third-party reference page

### DIFF
--- a/_data/modules/thirdparty.yaml
+++ b/_data/modules/thirdparty.yaml
@@ -565,3 +565,10 @@
   license: MIT
   maven:
     url: http://mvnrepository.com/artifact/com.tradier/dropwizard-raven
+  name: btm-DropwizardHealthChecks
+  url: https://github.com/BreakTheMonolith/btm-DropwizardHealthChecks
+  description: Provides pre-written health checks for JDBC supported databases, dependent Http(s) services, and more
+  dropwizard: 1.0
+  license: Apache 2.0
+  maven:
+    url: http://mvnrepository.com/artifact/guru.breakthemonolith/btm-DropwizardHealthChecks


### PR DESCRIPTION
Please consider adding the following entry to your Third Party reference page. If this isn't the proper procedure for such a request, please feel free to redirect me. Thanks for looking at this.

The project added at the end is https://github.com/BreakTheMonolith/btm-DropwizardHealthChecks

