### PR TITLE
Add dropwizard-sentry

### DIFF
--- a/_data/modules/thirdparty.yaml
+++ b/_data/modules/thirdparty.yaml
@@ -300,6 +300,13 @@
   license: MIT
   maven:
     url: http://mvnrepository.com/artifact/com.tradier/dropwizard-raven
+- name: dropwizard-sentry
+  url: https://github.com/dhatim/dropwizard-sentry
+  description: Dropwizard integration for error logging to Sentry
+  dropwizard: 1.3
+  license: Apache 2.0
+  maven:
+    url: http://mvnrepository.com/artifact/org.dhatim/dropwizard-sentry
 - name: btm-DropwizardHealthChecks
   url: https://github.com/BreakTheMonolith/btm-DropwizardHealthChecks
   description: Provides pre-written health checks for JDBC supported databases, dependent Http(s) services, and more


### PR DESCRIPTION
Forked from https://github.com/tradier/dropwizard-raven but uses the latest `sentry-logback` client instead of the deprecated `raven-logback`. Also, built with dropwizard 1.3.1.