### PR TITLE
Adding admin-resource and hibernate-test-util, updating circuitbreaker, hikaricp, and petite

### DIFF
--- a/_data/modules/thirdparty.yaml
+++ b/_data/modules/thirdparty.yaml
@@ -91,6 +91,51 @@
     url: https://repo1.maven.org/maven2/de/ahus1/keycloak/dropwizard/keycloak-dropwizard/
     groupId: de.ahus1.keycloak.dropwizard
     artifactId: keycloak-dropwizard
+- name: dropwizard-admin-resource
+  url: https://github.com/mtakaki/dropwizard-admin-resource/
+  description: Adds the ability to easily register resources under admin port
+  dropwizard: 1.3.8
+  license: Apache 2.0
+  maven:
+    url: http://central.maven.org/maven2/com/github/mtakaki/dropwizard-admin-resource/
+    groupId: com.github.mtakaki
+    artifactId: dropwizard-admin-resource
+- name: dropwizard-circuitbreaker
+  url: https://github.com/mtakaki/dropwizard-circuitbreaker/
+  description: Simple implementation of circuit breaker design pattern using annotations.
+  dropwizard: 1.3.8
+  license: GNU LGPL 2.0
+  maven:
+    url: http://central.maven.org/maven2/com/github/mtakaki/dropwizard-circuitbreaker/
+    groupId: com.github.mtakaki
+    artifactId: dropwizard-circuitbreaker
+- name: dropwizard-hibernate-test-util
+  url: https://github.com/mtakaki/dropwizard-hibernate-test-util/
+  description: Hibernate utility class for DAO jUnit tests
+  dropwizard: 1.3.8
+  license: MIT
+  maven:
+    url: http://central.maven.org/maven2/com/github/mtakaki/dropwizard-hibernate-test-util/
+    groupId: com.github.mtakaki
+    artifactId: dropwizard-hibernate-test-util
+- name: dropwizard-hikaricp
+  url: https://github.com/mtakaki/dropwizard-hikaricp/
+  description: A replacement for the hibernate and db packages. It replaces Tomcat connection pool with HikariCP.
+  dropwizard: 1.3.8
+  license: GNU LGPL 3.0
+  maven:
+    url: http://central.maven.org/maven2/com/github/mtakaki/dropwizard-hikaricp/
+    groupId: com.github.mtakaki
+    artifactId: dropwizard-hikaricp
+- name: dropwizard-petite
+  url: https://github.com/mtakaki/dropwizard-petite/
+  description: Light-weight dependency injection using Jodd Petite
+  dropwizard: 1.3.8
+  license: MIT
+  maven:
+    url: http://central.maven.org/maven2/com/github/mtakaki/dropwizard-petite/
+    groupId: com.github.mtakaki
+    artifactId: dropwizard-petite
 
 ## Bundles that have been tested on Dropwizard 1.2
 - name: dropwizard-money
@@ -341,15 +386,6 @@
     artifactId: dropwizard-prometheus
 
 ## Bundles that have been tested on Dropwizard 0.9
-- name: dropwizard-petite
-  url: https://github.com/mtakaki/dropwizard-petite
-  description: Light-weight dependency injection using Jodd Petite
-  dropwizard: 0.9.2
-  license: MIT
-  maven:
-    url: http://central.maven.org/maven2/com/github/mtakaki/dropwizard-petite/
-    groupId: com.github.mtakaki
-    artifactId: dropwizard-petite
 - name: dropwizard-auth-jwt
   url: https://github.com/ToastShaman/dropwizard-auth-jwt
   description: Dropwizard Authentication Module for Json Web Tokens (JWT)
@@ -359,15 +395,6 @@
     url: http://central.maven.org/maven2/com/github/toastshaman/dropwizard-auth-jwt/
     groupId: com.github.toastshaman
     artifactId: dropwizard-auth-jwt
-- name: dropwizard-circuitbreaker
-  url: https://github.com/mtakaki/dropwizard-circuitbreaker
-  description: Simple implementation of circuit breaker design pattern using annotations.
-  dropwizard: 0.9.2
-  license: GNU LGPL 2.0
-  maven:
-    url: http://central.maven.org/maven2/com/github/mtakaki/dropwizard-circuitbreaker/
-    groupId: com.github.mtakaki
-    artifactId: dropwizard-circuitbreaker
 - name: dropwizard-logentries-appender
   url: https://github.com/mtakaki/dropwizard-logentries-appender
   description: Log appender for logentries service.
@@ -377,15 +404,6 @@
     url: http://central.maven.org/maven2/com/github/mtakaki/logentries-appender/
     groupId: com.github.mtakaki
     artifactId: logentries-appender
-- name: dropwizard-hikaricp
-  url: https://github.com/mtakaki/dropwizard-hikaricp
-  description: A replacement for the hibernate and db packages. It replaces Tomcat connection pool with HikariCP.
-  dropwizard: 0.9.2
-  license: GNU LGPL 3.0
-  maven:
-    url: http://central.maven.org/maven2/com/github/mtakaki/dropwizard-hikaricp/
-    groupId: com.github.mtakaki
-    artifactId: dropwizard-hikaricp
 - name: dropwizard-websockets
   url: https://github.com/LivePersonInc/dropwizard-websockets
   description: websockets support including metrics


### PR DESCRIPTION
I've created these two libraries to allow to easily register resources under the admin port and a test rule for junit for testing hibernate DAOs. Circuit-breaker, hikaricp, and jodd petite integration was already in the page but I updated to be compatible with dropwizard 1.3.8.