### PR TITLE
update supported versions for keycloak dropwizard integration

### DIFF
--- a/_data/modules/thirdparty.yaml
+++ b/_data/modules/thirdparty.yaml
@@ -119,10 +119,9 @@
   url: https://github.com/ahus1/keycloak-dropwizard-integration/
   description: Integration of OAuth2 and OpenID Connect by using JBoss Keycloak
   dropwizard:
-    - 1.0.6
-    - 1.1.0
-    - 1.2.0
-    - 1.3.0
+    - 0.9
+    - 1.x
+    - 2.x
   license: Apache-2.0
   maven:
     groupId: de.ahus1.keycloak.dropwizard


### PR DESCRIPTION
I didn't update this for a while. I saw a reminder on Twitter, and here's the update.