### PR TITLE
update supported versions for keycloak dropwizard integration

### DIFF
--- a/_data/modules/thirdparty.yaml
+++ b/_data/modules/thirdparty.yaml
@@ -24,8 +24,8 @@
 
 ## Bundles that have been tested on Dropwizard 1.3
 - name: armeria-dropwizard
-  url: https://github.com/line/armeria/tree/master/dropwizard 
-  description: Allows for wrapping Armeria in place of Dropwizard's default Jetty Server 
+  url: https://github.com/line/armeria/tree/master/dropwizard
+  description: Allows for wrapping Armeria in place of Dropwizard's default Jetty Server
   dropwizard:
     - 1.3.16+
     - 2.0+
@@ -119,9 +119,10 @@
   url: https://github.com/ahus1/keycloak-dropwizard-integration/
   description: Integration of OAuth2 and OpenID Connect by using JBoss Keycloak
   dropwizard:
-    - 0.9
-    - 1.x
-    - 2.x
+    - '0.9'
+    - '1.x'
+    - '2.x'
+    - '3.x'
   license: Apache-2.0
   maven:
     groupId: de.ahus1.keycloak.dropwizard


### PR DESCRIPTION
The new release to support Dropwizard 3.0 was tagged and built to day, and will be available on Maven central soon.